### PR TITLE
Fix build with clang by correcting return types

### DIFF
--- a/src/libdwarf/dw_pe_utils.c
+++ b/src/libdwarf/dw_pe_utils.c
@@ -572,7 +572,7 @@ off_t get_pe_offset2(int sect,int num,int endoffset)
 	off_t offs;
 	char ss[15];
 	
-	if(!fc_ptr) return;
+	if(!fc_ptr) return 0;
 	maxsect=get_max_pesect();
 	mz=(_IMAGE_DOS_HEADER*)fc_ptr->faddr;
 	peoff=get_data32(mz->e_lfanew);

--- a/src/libdwarf/dw_switchers.c
+++ b/src/libdwarf/dw_switchers.c
@@ -155,7 +155,7 @@ struct _var* get_s_val(struct _structvar *ptr)
 }
 void set_s_val(struct _structvar *ptr,struct _var *val)
 {
-	if(!fc_ptr) {printf("unknown file.\n"); return NULL;}
+	if(!fc_ptr) {printf("unknown file.\n"); return;}
 	switch(fc_ptr->file_type){
 		case FT_ELF:
 			elf_set_s_val(ptr,val);

--- a/src/libdwarf/libdwarf.c
+++ b/src/libdwarf/libdwarf.c
@@ -335,7 +335,7 @@ int growth(off_t len)
 	off_t offset;
 	int n;
 	char *x;
-	if(!fc_ptr) {printf("no file opened!\n");return;}
+	if(!fc_ptr) {printf("no file opened!\n");return false;}
 	if(!fc_ptr->can_grow) {printf("this file cannot change its size\n"); return false;}
 	if(!fc_ptr->fd) {printf("no file opened!\n");return false;}
 	x=(char*)malloc(len);
@@ -357,7 +357,7 @@ int shrink(off_t len)
 {
 	off_t offset,new_offset;
 	int n;
-	if(!fc_ptr) {printf("no file opened!\n");return;}
+	if(!fc_ptr) {printf("no file opened!\n");return false;}
 	if(!fc_ptr->can_grow) {printf("this file cannot change its size\n"); return false;}
 	if(!fc_ptr->fd) {warn("no file opened!\n");return false;}
 	offset=lseek(fc_ptr->fd,(off_t)0,SEEK_END);


### PR DESCRIPTION
Prevents the following four errors when building with clang:

libdwarf.c:338:43: error: non-void function 'growth' should return a value [-Wreturn-type]
        if(!fc_ptr) {printf("no file opened!\n");return;}

libdwarf.c:360:43: error: non-void function 'shrink' should return a value [-Wreturn-type]
        if(!fc_ptr) {printf("no file opened!\n");return;}

dw_switchers.c:158:42: error: void function 'set_s_val' should not return a value [-Wreturn-type]
        if(!fc_ptr) {printf("unknown file.\n"); return NULL;}

dw_pe_utils.c:575:14: error: non-void function 'get_pe_offset2' should return a value [-Wreturn-type]
        if(!fc_ptr) return;

Closes elboza/dwarf-ng#2.
